### PR TITLE
Updates for building bidirectional-C++-interop on Windows

### DIFF
--- a/3_bidirectional_cxx_interop/CMakeLists.txt
+++ b/3_bidirectional_cxx_interop/CMakeLists.txt
@@ -16,6 +16,12 @@ if("${CMAKE_Swift_COMPILER_VERSION}" VERSION_LESS 5.9)
   message(FATAL_ERROR "Bidirectional C++ Interop requires Swift 5.9 or greater. Have ${CMAKE_Swift_COMPILER_VERSION}")
 endif()
 
+if(NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" AND
+   NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
+  message(FATAL_ERROR "Project requires building with Clang.
+  Have ${CMAKE_CXX_COMPILER_ID}")
+endif()
+
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules")
 
 # Set up swiftrt.o and runtime library search paths

--- a/3_bidirectional_cxx_interop/cmake/modules/AddSwift.cmake
+++ b/3_bidirectional_cxx_interop/cmake/modules/AddSwift.cmake
@@ -22,6 +22,8 @@ function(_swift_generate_cxx_header_target target module header)
 
   if(APPLE)
     set(SDK_FLAGS "-sdk" "${CMAKE_OSX_SYSROOT}")
+  elseif(WIN32)
+    set(SDK_FLAGS "-sdk" "$ENV{SDKROOT}")
   endif()
 
   add_custom_command(


### PR DESCRIPTION
There were some holes for building the bidirectional Swift-C++ example on Windows.
This patches those up.

First, Windows wasn't finding the standard library when generating the bridging header for the Swift library.
Second, Windows likes using MSVC, which was not amused by the generated header. This adds a check to ensure we're using Clang or AppleClang.
Third, the swiftrt file lives in the SDK instead of the toolchain on Windows, unlike on Linux. The driver reports the location of the toolchain libraries with `-print-target-info`, but does not for the SDK, so we have to grab the file manually. It would be nice if we could make the platforms more consistent, but this is a fix for now.

With these three changes, I was able to build and run the bidirectional C++ interop on Windows, built in Visual Studio.