### PR TITLE
Adding CMake version support ranges

### DIFF
--- a/1_single_executable/CMakeLists.txt
+++ b/1_single_executable/CMakeLists.txt
@@ -5,7 +5,7 @@
 #
 # See https://swift.org/LICENSE.txt for license information
 
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.22...3.29)
 
 project(hello LANGUAGES Swift)
 

--- a/2_executable_library/CMakeLists.txt
+++ b/2_executable_library/CMakeLists.txt
@@ -5,7 +5,7 @@
 #
 # See https://swift.org/LICENSE.txt for license information
 
-cmake_minimum_required(VERSION 3.22)
+cmake_minimum_required(VERSION 3.22...3.29)
 project(Project2 LANGUAGES Swift)
 
 add_subdirectory("lib/")

--- a/3_bidirectional_cxx_interop/CMakeLists.txt
+++ b/3_bidirectional_cxx_interop/CMakeLists.txt
@@ -5,7 +5,7 @@
 #
 # See https://swift.org/LICENSE.txt for license information
 
-cmake_minimum_required(VERSION 3.26)
+cmake_minimum_required(VERSION 3.26...3.29)
 
 # Project PingPong: Bouncing control flow between Swift and C++ like a ping pong
 #                   ball.

--- a/4_swift_macros/CMakeLists.txt
+++ b/4_swift_macros/CMakeLists.txt
@@ -5,11 +5,7 @@
 #
 # See https://swift.org/LICENSE.txt for license information
 
-cmake_minimum_required(VERSION 3.22)
-
-if(POLICY CMP0157)
-  cmake_policy(SET CMP0157 NEW)
-endif()
+cmake_minimum_required(VERSION 3.22...3.29)
 
 project(StringifyMacroExample
   LANGUAGES Swift)

--- a/4_swift_macros/StringifyMacro/CMakeLists.txt
+++ b/4_swift_macros/StringifyMacro/CMakeLists.txt
@@ -5,10 +5,7 @@
 #
 # See https://swift.org/LICENSE.txt for license information
 
-cmake_minimum_required(VERSION 3.22)
-if(POLICY CMP0157)
-  cmake_policy(SET CMP0157 NEW)
-endif()
+cmake_minimum_required(VERSION 3.22...3.29)
 
 project(StringifyMacro
   LANGUAGES Swift)


### PR DESCRIPTION
Adding the supported version ranges to each project. The newer versions of CMake have better support with some of the newer policies. Specifically CMP0157 in CMake 3.29 improves the incremental rebuild performance and hooks up the emissions of compile commands for Swift so that folks with Sourcekit-LSP can have a better editing experience.