### PR TITLE
PR Testing: Clean up test titles

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -10,20 +10,17 @@ on:
 
 jobs:
   smoke_test:
-    name: Smoke Test ( CMake ${{ matrix.cmake.version }} )
+    name: Smoke Test (CMake v${{ matrix.cmake.version }})
     runs-on: ubuntu-latest
     container: swift:6.1-bookworm
     strategy:
       matrix:
         cmake:
-          - version: v3.22.6
-            url: "https://github.com/Kitware/CMake/releases/download/v3.22.6/cmake-3.22.6-linux-x86_64.tar.gz"
+          - version: 3.22.6
             hash: 09e1b34026c406c5bf4d1b053eadb3a8519cb360e37547ebf4b70ab766d94fbc
-          - version: v3.26.6
-            url: "https://github.com/Kitware/CMake/releases/download/v3.26.6/cmake-3.26.6-linux-x86_64.tar.gz"
+          - version: 3.26.6
             hash: 2dd48ccd3e3d872ee4cc916f3f4e24812612421007e895f82bf9fc7e49831d62
-          - version: v3.30.8
-            url: "https://github.com/Kitware/CMake/releases/download/v3.30.8/cmake-3.30.8-linux-x86_64.tar.gz"
+          - version: 3.30.8
             hash: adc81f2944e6f86b44e86acea3abea1651ed7890206933484b8b74ac1280314f
     steps:
       - name: Clone Repo
@@ -37,7 +34,7 @@ jobs:
         id: install-cmake
         uses: ./swift-cmake-examples/.github/actions/cmake-action
         with:
-          url: ${{ matrix.cmake.url }}
+          url: "https://github.com/Kitware/CMake/releases/download/v${{matrix.cmake.version}}/cmake-${{matrix.cmake.version}}-linux-x86_64.tar.gz"
           hash: ${{ matrix.cmake.hash }}
       - name: Run Tests
         shell: bash

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -10,17 +10,20 @@ on:
 
 jobs:
   smoke_test:
-    name: Smoke Test
+    name: Smoke Test ( CMake ${{ matrix.cmake.version }} )
     runs-on: ubuntu-latest
     container: swift:6.1-bookworm
     strategy:
       matrix:
         cmake:
-          - url: "https://github.com/Kitware/CMake/releases/download/v3.22.6/cmake-3.22.6-linux-x86_64.tar.gz"
+          - version: v3.22.6
+            url: "https://github.com/Kitware/CMake/releases/download/v3.22.6/cmake-3.22.6-linux-x86_64.tar.gz"
             hash: 09e1b34026c406c5bf4d1b053eadb3a8519cb360e37547ebf4b70ab766d94fbc
-          - url: "https://github.com/Kitware/CMake/releases/download/v3.26.6/cmake-3.26.6-linux-x86_64.tar.gz"
+          - version: v3.26.6
+            url: "https://github.com/Kitware/CMake/releases/download/v3.26.6/cmake-3.26.6-linux-x86_64.tar.gz"
             hash: 2dd48ccd3e3d872ee4cc916f3f4e24812612421007e895f82bf9fc7e49831d62
-          - url: "https://github.com/Kitware/CMake/releases/download/v3.30.8/cmake-3.30.8-linux-x86_64.tar.gz"
+          - version: v3.30.8
+            url: "https://github.com/Kitware/CMake/releases/download/v3.30.8/cmake-3.30.8-linux-x86_64.tar.gz"
             hash: adc81f2944e6f86b44e86acea3abea1651ed7890206933484b8b74ac1280314f
     steps:
       - name: Clone Repo


### PR DESCRIPTION
The test titles use the full matrix value which isn't terribly helpful. Shortening it to just use the CMake version number instead of the URL and hash, which is what we are trying to test.