### PR TITLE
CMake 4.0.1 fixes

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -22,6 +22,8 @@ jobs:
             hash: 2dd48ccd3e3d872ee4cc916f3f4e24812612421007e895f82bf9fc7e49831d62
           - version: 3.30.8
             hash: adc81f2944e6f86b44e86acea3abea1651ed7890206933484b8b74ac1280314f
+          - version: 4.0.1
+            hash: d66c11c010588c8256ee20a26b45977cd5b2f4aee2b742d4b8a353769940d147
     steps:
       - name: Clone Repo
         uses: actions/checkout@v4

--- a/3_bidirectional_cxx_interop/cmake/modules/AddSwift.cmake
+++ b/3_bidirectional_cxx_interop/cmake/modules/AddSwift.cmake
@@ -34,11 +34,11 @@ function(_swift_generate_cxx_header target header)
     list(TRANSFORM ARG_SEARCH_PATHS PREPEND "-I")
   endif()
 
-  if(APPLE)
+  if(APPLE AND CMAKE_OSX_SYSROOT)
     set(SDK_FLAGS "-sdk" "${CMAKE_OSX_SYSROOT}")
   elseif(WIN32)
     set(SDK_FLAGS "-sdk" "$ENV{SDKROOT}")
-  elseif(DEFINED ${CMAKE_SYSROOT})
+  elseif(CMAKE_SYSROOT)
     set(SDK_FLAGS "-sdk" "${CMAKE_SYSROOT}")
   endif()
 
@@ -54,7 +54,7 @@ function(_swift_generate_cxx_header target header)
     DEPENDS ${_SwiftSources}
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     COMMAND
-      ${CMAKE_Swift_COMPILER} -frontend -typecheck
+      ${CMAKE_Swift_COMPILER} -typecheck
       ${ARG_SEARCH_PATHS}
       ${_SwiftSources}
       ${SDK_FLAGS}

--- a/3_bidirectional_cxx_interop/cmake/modules/InitializeSwift.cmake
+++ b/3_bidirectional_cxx_interop/cmake/modules/InitializeSwift.cmake
@@ -26,7 +26,7 @@ endfunction()
 function(_setup_swift_paths)
   # If we haven't set the swift library search paths, do that now
   if(NOT SWIFT_LIBRARY_SEARCH_PATHS)
-    if(APPLE)
+    if(CMAKE_OSX_SYSROOT)
       set(SDK_FLAGS "-sdk" "${CMAKE_OSX_SYSROOT}")
     endif()
 


### PR DESCRIPTION
CMake 4.0 and newer does not set `CMAKE_OSX_SYSROOT` by default. We should only explicitly pass an SDK when there is an SDK to pass.

Also adding CMake 4.0.1 to the set of CMake versions to test.

Fixes: https://github.com/apple/swift-cmake-examples/issues/18